### PR TITLE
update python-dateutil to 2.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ ago==0.0.6
 backports.ssl-match-hostname==3.4.0.2
 docker-py==1.2.3
 future==0.14.3
-python-dateutil==2.2
+python-dateutil==2.4.2
 python-tutum==0.16.0.1
 requests==2.7.0
 six==1.9.0


### PR DESCRIPTION
With the current version of python-dateutil there is a bug with converting timezones on windows. Any commands that use the get_humanize_local_datetime_from_utc_datetime_string function fail with
ValueError: month must be in 1..12

This bug has been fixed in python-dateutil 2.4.0 (2.4.2 is the latest).